### PR TITLE
Fix font styling in some languages

### DIFF
--- a/src/styles/host.ts
+++ b/src/styles/host.ts
@@ -15,7 +15,7 @@ export const hostStyle = css`
         --scrollbar-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
 
         /* Typography */
-        --font-family: 'Segoe UI', Arial, Roboto, Helvetica sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+        --font-family: 'Segoe UI', system-ui, Arial, Roboto, Helvetica sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
         --font-size: 9pt;
 
         /* Pre-determined dimensions */


### PR DESCRIPTION
Thank you for providing such excellent components. They have been immensely helpful in the project I am currently undertaking.

During my usage of the components, I noticed that the font for Japanese text within the Property Inspector does not match the font used outside of it.

To address this, my Pull Request proposes adding 'system-ui' to the font family. This change will ensure that a suitable UI font is automatically selected for any language, enhancing the overall consistency of the component.

The following images show a comparison before and after the applying of PR:

Current:
![image](https://github.com/GeekyEggo/sdpi-components/assets/18254610/6d7d4877-5017-4c79-abd6-afd89766bde6)

This PR:
![image](https://github.com/GeekyEggo/sdpi-components/assets/18254610/caa67e3a-6715-4de5-884f-3031b007e530)