### PR TITLE
fix: add zh to zh_CN mapping

### DIFF
--- a/src/core/__tests__/i18n.test.ts
+++ b/src/core/__tests__/i18n.test.ts
@@ -89,6 +89,17 @@ describe("i18n", () => {
 				// then.
 				expect(i18n.language).toBe("zh_CN");
 			});
+
+			it("should map to simplified Chinese without region", async () => {
+				// given.
+				jest.spyOn(window.navigator, "language", "get").mockReturnValue("zh");
+
+				// when
+				const i18n = (await import("../i18n")).default;
+
+				// then.
+				expect(i18n.language).toBe("zh_CN");
+			});
 		});
 	});
 

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -48,7 +48,7 @@ export class Internationalization {
 		}
 
 		// Chinese Simplified
-		if (language === "zh-Hans" || language === "zh-CN") {
+		if (language === "zh" || language === "zh-Hans" || language === "zh-CN") {
 			return "zh_CN";
 		}
 


### PR DESCRIPTION
With the local system's language set to Chinese (Simplified), the `window.navigator.language` is `zh`. To accommodate for no region being specified as part of the language, this PR maps `zh` to `zh_CN`.
![image](https://github.com/user-attachments/assets/8cca96bc-5382-4099-a7af-07b8a5ee2840)
