### PR TITLE
components: item: don't allow user select on label

### DIFF
--- a/src/components/sdpi-item.ts
+++ b/src/components/sdpi-item.ts
@@ -45,6 +45,7 @@ export class SdpiItem extends LitElement {
 				min-height: 28px;
 				padding-right: 11px;
 				text-align: right;
+				user-select: none;
 			}
 		`,
 	];


### PR DESCRIPTION
Does what it says on the tin.

Currently the user can select the item labels:

<img width="1462" height="666" alt="image" src="https://github.com/user-attachments/assets/ae5ac328-537c-4932-846d-71be0dfd0352" />


This brings them inline with the title label.