### PR TITLE
fix: error when `checkbox-list` receives invalid data

### DIFF
--- a/src/components/checkbox-list.ts
+++ b/src/components/checkbox-list.ts
@@ -37,7 +37,7 @@ export class CheckboxList extends Gridded(
 							html`
 								<input
 									type="checkbox"
-									.checked=${(this.value && this.value.findIndex((v) => v == item.value) > -1) ||
+									.checked=${(Array.isArray(this.value) && this.value.findIndex((v) => v == item.value) > -1) ||
 									false}
 									.disabled=${this.disabled || item.disabled || false}
 									.value=${item.value}


### PR DESCRIPTION
Hi There, I came across an error when switching from the `<sdpi-select>` component to `<sdpi-checkbox-list>`.  Becasue the data persisted in the setting was a string and not an array, I was getting an error along the lines of 

```
TypeError: 'findIndex' does not exist on 'this.value'
```

Although I can't see this ever affecting end-users at runtime, I think it would be beneficial to prevent this issue by first checking if the data is an Array by using `Array.isArray()`. There is already a fallback in place for when this condition fails. 